### PR TITLE
Add script and instuctions for LDAP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,31 @@ log in form. You can log in with your current user name and password you set in
 
 If your institution provides access to an LDAP (or Active Directory)
 server, you may use it to authenticate users to RStudio. You must
-first determine the following:
+first determine the following requirements for your LDAP server:
 
 1. The name of the LDAP host
 2. The base DN for users in the domain. A placeholder in the form '%s'
    will be replaced by the username provided to RStudio at the time of
    authentication.
-3. A public TLS certificate used for encryption of the LDAP session
+3. The TLS certificate used for encryption of the LDAP session (need not
+   be specified if the default system certificate store is permitted).
 
-For example:
+If the system cert file is accepted by the LDAP server:
 
 ```sh
 export LDAP_HOST=your.ldap.server.org
 export LDAP_USER_DN='CN=%s,CN=Users,DC=MyDomain,DC=com'
+singularity run singularity-rstudio.simg
+  --auth-none 0 \
+  --auth-pam-helper-path ldap_auth
+```
+
+Otherwise:
+
+```sh
+export LDAP_HOST=your.ldap.server.org
+export LDAP_USER_DN='CN=%s,CN=Users,DC=MyDomain,DC=com'
+export LDAP_CERT_FILE=/etc/ldap-cert.pem
 singularity run \
   --bind thawte_Primary_Root_CA.pem:/etc/ldap-cert.pem \
   singularity-rstudio.simg \
@@ -105,8 +117,8 @@ singularity run \
 ```
 
 Here the certificate file `thawte_Primary_Root_CA.pem` (used here only
-as an example) is bound to the default path for the certificate in the
-image.
+as an example) is bound to the specified path for the certificate in
+the image.
 
 ### R and Rscript
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,16 @@ server, you may use it to authenticate users to RStudio. You must
 first determine the following:
 
 1. The name of the LDAP host
-2. The base DN for users in the domain
+2. The base DN for users in the domain. A placeholder in the form '%s'
+   will be replaced by the username provided to RStudio at the time of
+   authentication.
 3. A public TLS certificate used for encryption of the LDAP session
 
 For example:
 
 ```sh
 export LDAP_HOST=your.ldap.server.org
-export LDAP_USER_DN='CN=Users,DC=MyDomain,DC=com'
+export LDAP_USER_DN='CN=%s,CN=Users,DC=MyDomain,DC=com'
 singularity run \
   --bind thawte_Primary_Root_CA.pem:/etc/ldap-cert.pem \
   singularity-rstudio.simg \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ server:
 ...
 ```
 
-#### Add Authentication
+#### Simple Password Authentication
 
 To secure the RStudio Server you will need to:
 
@@ -79,6 +79,32 @@ RSTUDIO_PASSWORD="password" singularity run singularity-rstudio.simg \
 Now when you attempt to access the RStudio Server you will be presented with a
 log in form. You can log in with your current user name and password you set in
 `RSTUDIO_PASSWORD`.
+
+#### LDAP Authentication
+
+If your institution provides access to an LDAP (or Active Directory)
+server, you may use it to authenticate users to RStudio. You must
+first determine the following:
+
+1. The name of the LDAP host
+2. The base DN for users in the domain
+3. A public TLS certificate used for encryption of the LDAP session
+
+For example:
+
+```sh
+export LDAP_HOST=your.ldap.server.org
+export LDAP_USER_DN='CN=Users,DC=MyDomain,DC=com'
+singularity run \
+  --bind thawte_Primary_Root_CA.pem:/etc/ldap-cert.pem \
+  singularity-rstudio.simg \
+  --auth-none 0 \
+  --auth-pam-helper-path ldap_auth
+```
+
+Here the certificate file `thawte_Primary_Root_CA.pem` (used here only
+as an example) is bound to the default path for the certificate in the
+image.
 
 ### R and Rscript
 

--- a/Singularity
+++ b/Singularity
@@ -21,6 +21,9 @@ From: nickjer/singularity-r
   install -Dv \
     rstudio_auth.sh \
     ${SINGULARITY_ROOTFS}/usr/lib/rstudio-server/bin/rstudio_auth
+  install -Dv \
+    ldap_auth.py \
+    ${SINGULARITY_ROOTFS}/usr/lib/rstudio-server/bin/ldap_auth
 
 %post
   # Software versions
@@ -31,13 +34,15 @@ From: nickjer/singularity-r
   apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
-    gdebi-core
+    gdebi-core \
+    python3-pip
   wget \
     --no-verbose \
     -O rstudio-server.deb \
     "https://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"
   gdebi -n rstudio-server.deb
   rm -f rstudio-server.deb
+  pip3 install ldap3
 
   # Clean up
   rm -rf /var/lib/apt/lists/*

--- a/Singularity.3.4.3
+++ b/Singularity.3.4.3
@@ -42,6 +42,7 @@ From: nickjer/singularity-r:3.4.3
     "https://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb"
   gdebi -n rstudio-server.deb
   rm -f rstudio-server.deb
+  pip3 install ldap3
 
   # Clean up
   rm -rf /var/lib/apt/lists/*

--- a/Singularity.3.4.3
+++ b/Singularity.3.4.3
@@ -21,6 +21,9 @@ From: nickjer/singularity-r:3.4.3
   install -Dv \
     rstudio_auth.sh \
     ${SINGULARITY_ROOTFS}/usr/lib/rstudio-server/bin/rstudio_auth
+  install -Dv \
+    ldap_auth.py \
+    ${SINGULARITY_ROOTFS}/usr/lib/rstudio-server/bin/ldap_auth
 
 %post
   # Software versions
@@ -31,7 +34,8 @@ From: nickjer/singularity-r:3.4.3
   apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
-    gdebi-core
+    gdebi-core \
+    python3-pip
   wget \
     --no-verbose \
     -O rstudio-server.deb \

--- a/ldap_auth.py
+++ b/ldap_auth.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+"""Verify a username and password combination using LDAP
+
+Reads a password from stdin, or prompts for a password if none is
+provided.
+
+Example usage:
+
+    % export LDAP_CERT_FILE=/path/to/trusted_root_cert.pem
+    % export LDAP_HOST=some.ldap.server.org
+    % export LDAP_USER_DN='CN=Users,DC=MyDomain,DC=com'
+    % ldap_auth.py username && echo ok || echo failed
+    Password:  # enter correct password
+    Success
+    ok
+    % ldap_auth.py username && echo ok || echo failed
+    Password:  # enter incorrect password
+    LDAPInvalidCredentialsResult - 49 - invalidCredentials - None - 80090308: LdapErr: DSID-0C09042F, comment: AcceptSecurityContext error, data 52e, v2580 - bindResponse - None
+    failed
+"""
+
+import os
+import sys
+import argparse
+import ssl
+import getpass
+
+import ldap3
+from ldap3.core.exceptions import LDAPInvalidCredentialsResult
+
+getenv = os.environ.get
+
+
+def main(arguments):
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('user')
+    parser.add_argument(
+        '--cert-file', default=getenv('LDAP_CERT_FILE') or '/etc/ldap-cert.pem',
+        help="""Path to TLS certificate used for encrypting the
+        connection to the LDAP server. Uses value of LDAP_CERT_FILE if
+        defined, or /etc/ldap-cert.pem otherwise.""")
+    parser.add_argument(
+        '--host', default=getenv('LDAP_HOST'),
+        help="""Name of the LDAP host. Uses value of LDAP_HOST
+        by default."""
+    )
+    parser.add_argument(
+        '--user-dn', default=getenv('LDAP_USER_DN'),
+        help="""Base DN for user search in LDAP directory (will look
+        something like "CN=Users,DC=MyDomain,DC=com"). Uses value of
+        LDAP_USER_DN by default."""
+    )
+    parser.add_argument(
+        '--timeout', type=int, default=3,
+        help='Timeout for LDAP server connection in seconds [%(default)s].')
+
+    args = parser.parse_args(arguments)
+
+    if not sys.stdin.isatty():  # stdin has content
+        password = sys.stdin.read().strip()
+    else:
+        password = getpass.getpass()
+
+    conn = ldap3.Connection(
+        ldap3.Server(
+            args.host,
+            port=636,
+            use_ssl=True,
+            tls=ldap3.Tls(
+                ca_certs_file=args.cert_file,
+                # validate=ssl.CERT_NONE,
+                validate=ssl.CERT_REQUIRED,
+            ),
+            get_info=ldap3.NONE,
+            connect_timeout=args.timeout,
+        ),
+        auto_bind=False,
+        client_strategy=ldap3.SYNC,
+        user='CN={},{}'.format(args.user, args.user_dn),
+        password=password,
+        raise_exceptions=True,
+        check_names=True)
+
+    conn.start_tls()
+
+    try:
+        conn.bind()
+    except LDAPInvalidCredentialsResult as err:
+        print(err)
+        status = 1
+    else:
+        print('Success')
+        status = 0
+    finally:
+        conn.unbind()
+        sys.exit(status)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/ldap_auth.py
+++ b/ldap_auth.py
@@ -7,7 +7,7 @@ provided.
 
 Example usage:
 
-    % export LDAP_CERT_FILE=/path/to/trusted_root_cert.pem
+    % export LDAP_CERT_FILE=/path/to/trusted_root_cert.pem  # optional, see [0]
     % export LDAP_HOST=some.ldap.server.org
     % export LDAP_USER_DN='CN=%s,CN=Users,DC=MyDomain,DC=com'
     % ldap_auth.py username && echo ok || echo failed
@@ -18,6 +18,10 @@ Example usage:
     Password:  # enter incorrect password
     LDAPInvalidCredentialsResult - 49 - invalidCredentials - None - 80090308: LdapErr: DSID-0C09042F, comment: AcceptSecurityContext error, data 52e, v2580 - bindResponse - None
     failed
+
+[0] A certificate file is only required if the default system
+certificate store is not accepted by the LDAP server.
+
 """
 
 import os
@@ -39,10 +43,10 @@ def main(arguments):
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('user')
     parser.add_argument(
-        '--cert-file', default=getenv('LDAP_CERT_FILE') or '/etc/ldap-cert.pem',
+        '--cert-file', default=getenv('LDAP_CERT_FILE'),
         help="""Path to TLS certificate used for encrypting the
         connection to the LDAP server. Uses value of LDAP_CERT_FILE if
-        defined, or /etc/ldap-cert.pem otherwise.""")
+        defined""")
     parser.add_argument(
         '--host', default=getenv('LDAP_HOST'),
         help="""Name of the LDAP host. Uses value of LDAP_HOST
@@ -52,7 +56,7 @@ def main(arguments):
         '--user-dn', default=getenv('LDAP_USER_DN'),
         help="""Base DN for user search in LDAP directory, including a
         placeholder for USER (will look something like
-        "CN=%s,CN=Users,DC=MyDomain,DC=com"). Uses value of
+        "CN=%%s,CN=Users,DC=MyDomain,DC=com"). Uses value of
         LDAP_USER_DN by default."""
     )
     parser.add_argument(

--- a/ldap_auth.py
+++ b/ldap_auth.py
@@ -9,7 +9,7 @@ Example usage:
 
     % export LDAP_CERT_FILE=/path/to/trusted_root_cert.pem
     % export LDAP_HOST=some.ldap.server.org
-    % export LDAP_USER_DN='CN=Users,DC=MyDomain,DC=com'
+    % export LDAP_USER_DN='CN=%s,CN=Users,DC=MyDomain,DC=com'
     % ldap_auth.py username && echo ok || echo failed
     Password:  # enter correct password
     Success
@@ -50,8 +50,9 @@ def main(arguments):
     )
     parser.add_argument(
         '--user-dn', default=getenv('LDAP_USER_DN'),
-        help="""Base DN for user search in LDAP directory (will look
-        something like "CN=Users,DC=MyDomain,DC=com"). Uses value of
+        help="""Base DN for user search in LDAP directory, including a
+        placeholder for USER (will look something like
+        "CN=%s,CN=Users,DC=MyDomain,DC=com"). Uses value of
         LDAP_USER_DN by default."""
     )
     parser.add_argument(
@@ -80,7 +81,7 @@ def main(arguments):
         ),
         auto_bind=False,
         client_strategy=ldap3.SYNC,
-        user='CN={},{}'.format(args.user, args.user_dn),
+        user=args.user_dn % args.user,
         password=password,
         raise_exceptions=True,
         check_names=True)


### PR DESCRIPTION
Here is a solution that I came up with to provide authentication to RStudio sessions using LDAP. I completely understand if you'd prefer not to add (or field questions about) this functionality - if not, I can most likely find a way to provide the LDAP authentication script separately,  or just maintain a fork that provides it.

Thanks a lot,
Noah