### PR TITLE
Pin ldap3 version and update params for SSL validation

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -49,7 +49,7 @@ From: nickjer/singularity-r
     "https://bootstrap.pypa.io/get-pip.py"
   python3 get-pip.py
   rm -f get-pip.py
-  pip3 install ldap3
+  pip3 install 'ldap3==2.9'
 
   # Clean up
   rm -rf /var/lib/apt/lists/*

--- a/Singularity.3.6.2
+++ b/Singularity.3.6.2
@@ -49,7 +49,7 @@ From: nickjer/singularity-r:3.6.2
     "https://bootstrap.pypa.io/get-pip.py"
   python3 get-pip.py
   rm -f get-pip.py
-  pip3 install ldap3
+  pip3 install 'ldap3==2.9'
 
   # Clean up
   rm -rf /var/lib/apt/lists/*

--- a/ldap_auth.py
+++ b/ldap_auth.py
@@ -19,8 +19,9 @@ Example usage:
     LDAPInvalidCredentialsResult - 49 - invalidCredentials - None - 80090308: LdapErr: DSID-0C09042F, comment: AcceptSecurityContext error, data 52e, v2580 - bindResponse - None
     failed
 
-[0] A certificate file is only required if the default system
-certificate store is not accepted by the LDAP server.
+[0] A certificate file is only required if mandared by the LDAP host
+and the default system certificate store is not accepted by the LDAP
+server.
 
 """
 
@@ -77,8 +78,7 @@ def main(arguments):
             use_ssl=True,
             tls=ldap3.Tls(
                 ca_certs_file=args.cert_file,
-                # validate=ssl.CERT_NONE,
-                validate=ssl.CERT_REQUIRED,
+                validate=ssl.CERT_OPTIONAL,
             ),
             get_info=ldap3.NONE,
             connect_timeout=args.timeout,

--- a/ldap_auth.py
+++ b/ldap_auth.py
@@ -19,7 +19,7 @@ Example usage:
     LDAPInvalidCredentialsResult - 49 - invalidCredentials - None - 80090308: LdapErr: DSID-0C09042F, comment: AcceptSecurityContext error, data 52e, v2580 - bindResponse - None
     failed
 
-[0] A certificate file is only required if mandared by the LDAP host
+[0] A certificate file is only required if mandated by the LDAP host
 and the default system certificate store is not accepted by the LDAP
 server.
 


### PR DESCRIPTION
The behavior of SSL certificate validation seems to have changed in recent versions of ldap3. This PR pins the version of ldap3 to avoid future unexpected changes in behavior, and updates a parameter to cause validation to occur only when a certificate is provided.

Thanks for considering!